### PR TITLE
Store track data as files

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,9 +17,11 @@ services:
       dockerfile: ./Dockerfile
     volumes:
       - ./src:/opt/obsAPI/src
+      - ./local/api-data:/data
     environment:
       - PORT=3000
       - MONGODB_URL=mongodb://mongo/obsTest
+      - UPLOADS_DIR=/data
     links:
       - mongo
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     environment:
       - PORT=3000
       - MONGODB_URL=mongodb://mongo/obsTest
-      - UPLOADS_DIR=/data
+      - DATA_DIR=/data
     links:
       - mongo
     ports:

--- a/migrations/2020-12-12-1823-original-filename.js
+++ b/migrations/2020-12-12-1823-original-filename.js
@@ -1,0 +1,21 @@
+const Track = require('../src/models/Track');
+
+module.exports = {
+  async up(next) {
+    try {
+      for await (const track of Track.find()) {
+        track.originalFileName = track.slug + '.csv'
+        await track.generateOriginalFilePath();
+        await track.save()
+      }
+      next();
+    } catch(err) {
+      next(err)
+    }
+  },
+
+  async down(next) {
+    next();
+  },
+};
+

--- a/migrations/2020-12-13-2025-move-to-upload-file.js
+++ b/migrations/2020-12-13-2025-move-to-upload-file.js
@@ -1,0 +1,25 @@
+
+const Track = require('../src/models/Track');
+
+module.exports = {
+  async up(next) {
+    try {
+      for await (const track of Track.find()) {
+        if (!track.body) {
+          continue
+        }
+
+        await track.writeToOriginalFile(track.body)
+        delete track.body;
+        await track.save()
+      }
+      next();
+    } catch(err) {
+      next(err)
+    }
+  },
+
+  async down(next) {
+    next();
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9308,6 +9308,14 @@
         }
       }
     },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "sanitize-html": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.1.tgz",
@@ -10167,6 +10175,14 @@
         "punycode": "^2.1.1"
       }
     },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -10956,6 +10972,11 @@
       "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
       "integrity": "sha1-Qw/VEKt/yVtdWRDJAteYgMIIQ2s=",
       "dev": true
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "passport": "0.4.1",
     "passport-local": "1.0.0",
     "request": "2.88.2",
+    "sanitize-filename": "^1.6.3",
     "slug": "^3.3.5",
     "turf": "^3.0.14",
     "underscore": "^1.11.0"

--- a/src/logic/tracks.js
+++ b/src/logic/tracks.js
@@ -64,6 +64,9 @@ function replaceDollarNewlinesHack(body) {
 }
 
 function* parseTrackPoints(body, format = null) {
+  if (body instanceof Buffer) {
+    body = body.toString('utf-8')
+  }
   body = replaceDollarNewlinesHack(body);
 
   const detectedFormat = format != null ? format : detectFormat(body);

--- a/src/models/Track.js
+++ b/src/models/Track.js
@@ -64,7 +64,7 @@ class Track extends mongoose.Model {
 
   async generateOriginalFilePath() {
     await this.populate('author').execPopulate();
-    this.originalFilePath = path.join('uploads', 'originals', this.author.username, this.slug, this.originalFileName);
+    this.originalFilePath = path.join('uploads', 'originals', this.author.username, this.slug, 'original.csv');
   }
 
   isVisibleTo(user) {

--- a/src/routes/api/tracks.js
+++ b/src/routes/api/tracks.js
@@ -359,4 +359,17 @@ router.get(
   }),
 );
 
+// download the original file
+router.get(
+  '/:track/download',
+  auth.optional,
+  wrapRoute(async (req, res) => {
+    if (!req.track.isVisibleTo(req.user)) {
+      return res.sendStatus(403);
+    }
+
+    return res.sendFile(req.track.fullOriginalFilePath)
+  }),
+);
+
 module.exports = router;

--- a/src/routes/api/tracks.js
+++ b/src/routes/api/tracks.js
@@ -78,7 +78,7 @@ router.get(
     }
 
     const [tracks, tracksCount] = await Promise.all([
-      Track.find(query).limit(Number(limit)).skip(Number(offset)).sort({ createdAt: 'desc' }).populate('author').exec(),
+      Track.find(query).sort('-createdAt').limit(Number(limit)).skip(Number(offset)).sort({ createdAt: 'desc' }).populate('author').exec(),
       Track.countDocuments(query).exec(),
     ]);
 
@@ -106,7 +106,7 @@ router.get(
 
     const query = { author: req.user.id };
     const [tracks, tracksCount] = await Promise.all([
-      Track.find(query).limit(Number(limit)).skip(Number(offset)).populate('author').exec(),
+      Track.find(query).sort('-createdAt').limit(Number(limit)).skip(Number(offset)).populate('author').exec(),
       Track.countDocuments(query),
     ]);
 

--- a/src/routes/api/tracks.js
+++ b/src/routes/api/tracks.js
@@ -368,7 +368,7 @@ router.get(
       return res.sendStatus(403);
     }
 
-    return res.sendFile(req.track.fullOriginalFilePath)
+    return res.download(req.track.fullOriginalFilePath)
   }),
 );
 


### PR DESCRIPTION
This solves #18 by moving track data from the `.body` attribute to a separate file. It also removes the deprecated separate `/begin`, `/add` and `/end` endpoints. This will cause the frontend to show the original filename (since the API starts publishing it), and will allow frontend developers to add functionality for downlodaing the original file as-is. Non-author users will be able to download the `publicTrackData` contents (generated as a CSV on the fly when requested) instead.